### PR TITLE
Expose the API on the scope as "vg".

### DIFF
--- a/app/scripts/com/2fdevs/videogular/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/videogular.js
@@ -272,6 +272,8 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
 					};
 
 					// PRIVATE FUNCTIONS
+					$scope.vg = this;
+
 					$scope.init = function() {
 						vg.updateTheme($scope.theme);
 						$scope.addBindings();


### PR DESCRIPTION
Sometimes it's easier/better to access the API directly from the template - without using plugins.

``` html
<videogular>
  <video ...>
  <div class="controls"
    hm-tap="vg.playPause()"
    hm-double-tap="vg.toggleFullScreen()"
    ></div>
</videogular>
```
