### PR TITLE
wrapping controller in an array to avoid #angular-minification-problems

### DIFF
--- a/app/scripts/com/2fdevs/videogular/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/videogular.js
@@ -163,7 +163,7 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
 					vgUpdateState: "&",
 					vgPlayerReady: "&"
 				},
-				controller: function($scope) {
+				controller: ['$scope', function($scope) {
 					var currentTheme = null;
 					var currentWidth = null;
 					var currentHeight = null;
@@ -583,7 +583,7 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
 					};
 
 					$scope.init();
-				},
+				}],
 				link: {
 					pre: function(scope, elem, attr, controller) {
 						controller.videogularElement = elem;


### PR DESCRIPTION
Angularjs sometimes looses its variable bindings when minified -- section on "A Note on Minification" in the following link explains a bit more if curious.

http://docs.angularjs.org/tutorial/step_05
