### PR TITLE
inline html templates for all plugins

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/buffering.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/buffering.js
@@ -6,7 +6,10 @@ angular.module("com.2fdevs.videogular.plugins.buffering", [])
 			return {
 				restrict: "E",
 				require: "^videogular",
-				templateUrl: "views/videogular/plugins/buffering/buffering.html",
+				template: "<div class='bufferingContainer'>"+
+										"<div class='loadingSpinner stop'></div>"+
+									"</div>"
+				,
 				link: function(scope, elem, attr, API) {
 					var spinner = angular.element(elem[0].getElementsByClassName("loadingSpinner"));
 

--- a/app/scripts/com/2fdevs/videogular/plugins/controls.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/controls.js
@@ -7,7 +7,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 				restrict: "E",
 				require: "^videogular",
 				transclude: true,
-				templateUrl: "views/videogular/plugins/controls/controls.html",
+				template: '<div id="controls-container" ng-show="isReady" ng-class="animationClass" ng-transclude></div>',
 				scope: {
 					autoHide: "=vgAutohide",
 					autoHideTime: "=vgAutohideTime"
@@ -93,7 +93,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 			return {
 				restrict: "E",
 				require: "^videogular",
-				templateUrl: "views/videogular/plugins/controls/play-pause-button.html",
+				template: "<div class='iconButton'>{{currentIcon}}</div>",
 				scope: {
 					vgPlayIcon: "=",
 					vgPauseIcon: "="
@@ -352,7 +352,13 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 			return {
 				restrict: "E",
 				require: "^videogular",
-				templateUrl: "views/videogular/plugins/controls/volume-bar.html",
+				template: "<div class='verticalVolumeBar'>"+
+										"<div class='volumeBackground'>"+
+											"<div class='volumeValue'></div>"+
+											"<div class='volumeClickArea'></div>"+
+										"</div>"+
+									"</div>"
+				,
 				link: function(scope, elem, attr, API) {
 					var isChangingVolume = false;
 					var volumeBackElem = angular.element(elem[0].getElementsByClassName("volumeBackground"));
@@ -441,7 +447,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 					$scope.volumeLevel3Icon = $.parseHTML($scope.vgVolumeLevel3Icon)[0].data;
 					$scope.currentIcon = $scope.volumeLevel3Icon;
 				},
-				templateUrl: "views/videogular/plugins/controls/mute-button.html",
+				template: "<div class='iconButton'>{{currentIcon}}</div>",
 				link: function(scope, elem, attr, API) {
 					function onClickMute(event) {
 						if (scope.currentIcon == scope.muteIcon) {
@@ -516,7 +522,7 @@ angular.module("com.2fdevs.videogular.plugins.controls", [])
 					$scope.exitFullScreenIcon = $.parseHTML($scope.vgExitFullScreenIcon)[0].data;
 					$scope.currentIcon = $scope.enterFullScreenIcon;
 				},
-				templateUrl: "views/videogular/plugins/controls/full-screen-button.html",
+				template: "<div class='iconButton'>{{currentIcon}}</div>",
 				link: function(scope, elem, attr, API) {
 					function onEnterFullScreen() {
 						scope.fullscreenIcon = scope.exitFullScreenIcon;

--- a/app/scripts/com/2fdevs/videogular/plugins/overlay-play.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/overlay-play.js
@@ -13,7 +13,10 @@ angular.module("com.2fdevs.videogular.plugins.overlayplay", [])
 					$scope.playIcon = $.parseHTML($scope.vgPlayIcon)[0].data;
 					$scope.currentIcon = $scope.playIcon;
 				},
-				templateUrl: "views/videogular/plugins/overlay-play/overlay-play.html",
+				template: "<div class='overlayPlayContainer'>"+
+                    "<div class='iconButton'>{{currentIcon}}</div>"+
+                  "</div>"
+        ,
 				link: function(scope, elem, attr, API) {
 					function onComplete(target, params) {
 						scope.currentIcon = scope.playIcon;

--- a/app/scripts/com/2fdevs/videogular/plugins/poster.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/poster.js
@@ -10,7 +10,7 @@ angular.module("com.2fdevs.videogular.plugins.poster", [])
 					vgUrl: "=",
 					vgStretch: "="
 				},
-				templateUrl: "views/videogular/plugins/poster/poster.html",
+				template: '<img ng-src="{{vgUrl}}" ng-class="vgStretch">',
 				link: function(scope, elem, attr, API) {
 					var img = elem.find("img");
 					var width = 0;

--- a/app/views/videogular/plugins/buffering/buffering.html
+++ b/app/views/videogular/plugins/buffering/buffering.html
@@ -1,3 +1,0 @@
-<div class='bufferingContainer'>
-	<div class='loadingSpinner stop'></div>
-</div>

--- a/app/views/videogular/plugins/controls/controls.html
+++ b/app/views/videogular/plugins/controls/controls.html
@@ -1,1 +1,0 @@
-<div id="controls-container" ng-show="isReady" ng-class="animationClass" ng-transclude></div>

--- a/app/views/videogular/plugins/controls/full-screen-button.html
+++ b/app/views/videogular/plugins/controls/full-screen-button.html
@@ -1,1 +1,0 @@
-<div class='iconButton'>{{currentIcon}}</div>

--- a/app/views/videogular/plugins/controls/mute-button.html
+++ b/app/views/videogular/plugins/controls/mute-button.html
@@ -1,1 +1,0 @@
-<div class='iconButton'>{{currentIcon}}</div>

--- a/app/views/videogular/plugins/controls/play-pause-button.html
+++ b/app/views/videogular/plugins/controls/play-pause-button.html
@@ -1,1 +1,0 @@
-<div class='iconButton'>{{currentIcon}}</div>

--- a/app/views/videogular/plugins/controls/volume-bar.html
+++ b/app/views/videogular/plugins/controls/volume-bar.html
@@ -1,6 +1,0 @@
-<div class='verticalVolumeBar'>
-	<div class='volumeBackground'>
-		<div class='volumeValue'></div>
-		<div class='volumeClickArea'></div>
-	</div>
-</div>

--- a/app/views/videogular/plugins/overlay-play/overlay-play.html
+++ b/app/views/videogular/plugins/overlay-play/overlay-play.html
@@ -1,3 +1,0 @@
-<div class='overlayPlayContainer'>
-	<div class='iconButton'>{{currentIcon}}</div>
-</div>

--- a/app/views/videogular/plugins/poster/poster.html
+++ b/app/views/videogular/plugins/poster/poster.html
@@ -1,1 +1,0 @@
-<img ng-src="{{vgUrl}}" ng-class="vgStretch">


### PR DESCRIPTION
inline `template` removes the need to relocate plugin views...
