### PR TITLE
remove error caused by setting video source when newValue is undefined

### DIFF
--- a/app/scripts/com/2fdevs/videogular/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/videogular.js
@@ -742,7 +742,7 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
 						}
 
 						scope.$watch(attr.vgSrc, function(newValue, oldValue) {
-							if (!sources || newValue != oldValue) {
+							if ((!sources || newValue != oldValue) && newValue) {
 								sources = newValue;
 								changeSource();
 							}


### PR DESCRIPTION
I'm seeing an error when I set the ng-src of the <video> element.  The object that I'm setting the source to is empty until a service retrieves the value.  The error is:
TypeError: Cannot read property 'length' of undefined
    at changeSource (http://174.129.231.36:9000/bower_components/videogular/videogular.js:718:36)
    at Object.fn (http://174.129.231.36:9000/bower_components/videogular/videogular.js:743:9)
    at Scope.$digest (http://174.129.231.36:9000/bower_components/angular/angular.js:11761:29)
    at Scope.$apply (http://174.129.231.36:9000/bower_components/angular/angular.js:12012:24)
    at done (http://174.129.231.36:9000/bower_components/angular/angular.js:7818:45)
    at completeRequest (http://174.129.231.36:9000/bower_components/angular/angular.js:7991:7)
    at XMLHttpRequest.xhr.onreadystatechange (http://174.129.231.36:9000/bower_components/angular/angular.js:7947:11)

Once the service retrieves the value - the video source is updated and the video works properly.  This PR should remove the error in the case that the src is an empty variable.
