### PR TITLE
Improved precision when converting dates to UTC

### DIFF
--- a/app/scripts/com/2fdevs/videogular/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/videogular.js
@@ -55,7 +55,7 @@ angular.module("com.2fdevs.videogular", ["ngSanitize"])
     };
 
     this.toUTCDate = function(date){
-      return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),  date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds());
+      return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds(), date.getUTCMilliseconds());
     };
 
     this.secondsToDate = function (seconds) {


### PR DESCRIPTION
Currently, the code looses to the millisecond level precision when dates are converted to UTC. This causes problems if we're trying to access the video on a per-frame basis since we can't reliably seek to time values like 4.545 seconds etc. The time difference between two frames in a 23.976 fps video comes down to about 4.17 milliseconds, and the API actually allows us to seek to that value using `API.seekTime()` but once we read back the value using `API.currentTime`, it looses the millisecond level precision.
