### PR TITLE
New feature: Playback rate

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -13,6 +13,7 @@
  * - playPause(): Toggles play and pause.
  * - seekTime(value, byPercent): Seeks to a specified time position. Param value must be an integer representing the target position in seconds or a percentage. By default seekTime seeks by seconds, if you want to seek by percentage just pass byPercent to true.
  * - setVolume(volume): Sets volume. Param volume must be an integer with a value between 0 and 1.
+ * - setPlayback(playback): Sets playback. Param plaback must be an integer with a value between 0 and 2.
  * - setState(state): Sets a new state. Param state mus be an string with 'play', 'pause' or 'stop'. This method only changes the state of the player, but doesn't plays, pauses or stops the media file.
  * - toggleFullScreen(): Toggles between fullscreen and normal mode.
  * - updateTheme(css-url): Removes previous CSS theme and sets a new one.
@@ -58,6 +59,7 @@
  * - totalTime: Number value with total media time.
  * - timeLeft: Number value with current media time left.
  * - volume: Number value with current volume between 0 and 1.
+ * - playback: Number value with current playback between 0 and 2.
  *
  */
 angular.module("com.2fdevs.videogular")
@@ -192,6 +194,11 @@ angular.module("com.2fdevs.videogular")
       $scope.$apply();
     };
 
+    this.onPlaybackChange = function () {
+      this.playback = this.mediaElement[0].playbackRate;
+      $scope.$apply();
+    };
+
     this.seekTime = function (value, byPercent) {
       var second;
       if (byPercent) {
@@ -302,6 +309,13 @@ angular.module("com.2fdevs.videogular")
       this.volume = newVolume;
     };
 
+    this.setPlayback = function (newPlayback) {
+      $scope.vgUpdatePlayback({$playBack: newPlayback});
+
+      this.mediaElement[0].playbackRate = newPlayback;
+      this.playback = newPlayback;
+    };
+
     this.updateTheme = function (value) {
       var links = document.getElementsByTagName("link");
       var i;
@@ -367,6 +381,7 @@ angular.module("com.2fdevs.videogular")
       this.mediaElement[0].addEventListener("play", this.onPlay.bind(this), false);
       this.mediaElement[0].addEventListener("pause", this.onPause.bind(this), false);
       this.mediaElement[0].addEventListener("volumechange", this.onVolumeChange.bind(this), false);
+      this.mediaElement[0].addEventListener("playbackchange", this.onPlaybackChange.bind(this), false);
       this.mediaElement[0].addEventListener("timeupdate", this.onUpdateTime.bind(this), false);
       this.mediaElement[0].addEventListener("error", this.onVideoError.bind(this), false);
     };

--- a/app/scripts/com/2fdevs/videogular/directives/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/directives/videogular.js
@@ -87,6 +87,7 @@
  * </pre>
  * @param {function} vgComplete Function name in controller's scope to call when video have been completed.
  * @param {function} vgUpdateVolume Function name in controller's scope to call when volume changes. Receives a param with the new volume.
+ * @param {function} vgUpdatePlayback Function name in controller's scope to call when playback changes. Receives a param with the new playback rate.
  * @param {function} vgUpdateTime Function name in controller's scope to call when video playback time is updated. Receives two params with current time and duration in milliseconds.
  * @param {function} vgUpdateState Function name in controller's scope to call when video state changes. Receives a param with the new state. Possible values are "play", "stop" or "pause".
  * @param {function} vgPlayerReady Function name in controller's scope to call when video have been initialized. Receives a param with the videogular API.
@@ -111,6 +112,7 @@ angular.module("com.2fdevs.videogular")
         vgConfig: "@",
         vgComplete: "&",
         vgUpdateVolume: "&",
+        vgUpdatePlayback: "&",
         vgUpdateTime: "&",
         vgUpdateState: "&",
         vgPlayerReady: "&",

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
@@ -34,7 +34,6 @@ angular.module("com.2fdevs.videogular.plugins.controls")
         link: function (scope, elem, attr, API) {
 
           scope.playback = '1.0';
-          var playbackValueElem = angular.element(elem[0].getElementsByClassName("playbackValue"));
 
           scope.onClickPlayback = function onClickPlayback() {
 

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
@@ -1,0 +1,63 @@
+/**
+ * @ngdoc directive
+ * @name com.2fdevs.videogular.plugins.controls.directive:ngPlaybackButton
+ * @restrict E
+ * @description
+ * Directive to display a playback buttom to control the playback rate.
+ *
+ * <pre>
+ * <videogular vg-theme="config.theme.url">
+ *    <vg-media vg-src="sources"></vg-media>
+ *
+ *    <vg-controls vg-autohide='config.autohide' vg-autohide-time='config.autohideTime'>
+ *        <vg-playback-button></vg-playback-button>
+ *    </vg-controls>
+ * </videogular>
+ * </pre>
+ *
+ */
+angular.module("com.2fdevs.videogular.plugins.controls")
+  .run(
+    ["$templateCache", function($templateCache) {
+      $templateCache.put("vg-templates/vg-playback-button",
+        '<button class="playbackValue iconButton" ng-click="onClickPlayback()">{{playback}}x</button>');
+    }]
+  )
+  .directive("vgPlaybackButton",
+    ["VG_UTILS", function (VG_UTILS) {
+      return {
+        restrict: "E",
+        require: "^videogular",
+        templateUrl: function(elem, attrs) {
+          return attrs.vgTemplate || 'vg-templates/vg-playback-button';
+        },
+        link: function (scope, elem, attr, API) {
+
+          scope.playback = '1.0';
+          var playbackValueElem = angular.element(elem[0].getElementsByClassName("playbackValue"));
+
+          scope.onClickPlayback = function onClickPlayback() {
+
+            var playbackOptions = ['.5', '1.0', '1.5', '2.0'];
+            
+            var nextPlaybackRate = playbackOptions.indexOf(scope.playback)+1;
+
+            if(nextPlaybackRate >= playbackOptions.length) {
+                scope.playback = playbackOptions[0];
+            }
+            else {
+                scope.playback = playbackOptions[nextPlaybackRate];
+            }
+
+            API.setPlayback(scope.playback);
+          };
+
+          scope.$watch(
+            function () {
+              return API.playback;
+            }
+          );
+        }
+      }
+    }]
+  );

--- a/app/styles/themes/default/videogular.css
+++ b/app/styles/themes/default/videogular.css
@@ -178,6 +178,12 @@ videogular, [videogular] {
     height: 100%;
     display: block;
     cursor: pointer; }
+  videogular vg-playback-button, [videogular] vg-playback-button {
+    display: table-cell;
+    width: 50px;
+    vertical-align: middle;
+    text-align: center;
+    cursor: pointer; }
   videogular vg-volume, [videogular] vg-volume {
     display: table-cell;
     width: 50px;


### PR DESCRIPTION
This PR was created to add support for video/audio playback speed adjustment.

It's designed to work with the vg-controls plugin. Playback speeds are set in an array and currently support .5 speed, 1.5 speed, and 2 speed.

If accepted, this PR will solve issue #189. 

Here's what it looks like once it's setup: 

![playback](https://cloud.githubusercontent.com/assets/8104596/7100354/71016224-dfd2-11e4-8184-95507bcddbd3.png)
