### PR TITLE
more precise iOS device detection

### DIFF
--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -53,7 +53,7 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.isiOSDevice = function () {
-            return (navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) || navigator.userAgent.match(/iPad/i));
+            return (navigator.userAgent.match(/ip(hone|ad|od)/i) && !navigator.userAgent.match(/(iemobile)[\/\s]?([\w\.]*)/i));
         };
 
         /**


### PR DESCRIPTION
Hi,
I had problems with Videogular recognising a WP8.1 phone with IE11 as an iOS device. It of course, tried to use 'webkitEnterFullscreen' function and crashed.
I updated the userAgent checking for a bit more precise check.
Also you should consider using a reliable UA parser (I recommend *ua-parser-js* bower package) as a dependency for this purpose. They are usually a bit heavy for a single check, so it's something the Videogular team should consider.

I hope you can also test this PR, it works for me and this specific WP and it still works on all available iOS devices I have access to.