### PR TITLE
Autoplay enabled for mobile devices on cordova

### DIFF
--- a/app/scripts/com/2fdevs/videogular/directives/vg-media.js
+++ b/app/scripts/com/2fdevs/videogular/directives/vg-media.js
@@ -85,7 +85,7 @@ angular.module("com.2fdevs.videogular")
                     if (VG_UTILS.isMobileDevice()) API.mediaElement[0].load();
 
                     $timeout(function () {
-                        if (API.autoPlay && !VG_UTILS.isMobileDevice()) {
+                        if (API.autoPlay && (VG_UTILS.isCordova() || !VG_UTILS.isMobileDevice())) {
                             API.play();
                         }
                     });

--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -56,6 +56,10 @@ angular.module("com.2fdevs.videogular")
             return (navigator.userAgent.match(/iPhone/i) || navigator.userAgent.match(/iPod/i) || navigator.userAgent.match(/iPad/i));
         };
 
+        this.isCordova = function () {
+            return document.URL.indexOf('http://') === -1 && document.URL.indexOf('https://') === -1;
+        };
+
         /**
          * Test the browser's support for HTML5 localStorage.
          * @returns {boolean}


### PR DESCRIPTION
Cordova/phonegap allows autoplay by default. In particular calling
play() directly always works.