### PR TITLE
Playback plugin support improvements

### DIFF
--- a/app/scripts/com/2fdevs/videogular/directives/vg-media.js
+++ b/app/scripts/com/2fdevs/videogular/directives/vg-media.js
@@ -44,7 +44,7 @@ angular.module("com.2fdevs.videogular")
 
                 // FUNCTIONS
                 scope.onChangeSource = function onChangeSource(newValue, oldValue) {
-                    if ((!sources || newValue != oldValue) && newValue) {
+                    if (newValue && (!sources || JSON.stringify(newValue) != JSON.stringify(oldValue)) && sources !== newValue) {
                         sources = newValue;
 
                         if (API.currentState !== VG_STATES.PLAY) {
@@ -58,6 +58,7 @@ angular.module("com.2fdevs.videogular")
 
                         API.sources = sources;
                         scope.changeSource();
+                        API.changeSource(newValue);
                     }
                 };
 
@@ -76,7 +77,7 @@ angular.module("com.2fdevs.videogular")
                                     API.mediaElement.attr("src", sources[i].src);
                                     API.mediaElement.attr("type", sources[i].type);
                                     //Trigger vgChangeSource($source) API callback in vgController
-                                    API.changeSource(sources[i]);
+                                    API.changeActiveSource(sources[i]);
                                     break;
                                 }
                             }
@@ -87,7 +88,7 @@ angular.module("com.2fdevs.videogular")
                             if (playbackPluginResult) {
                                 canPlay = "probably";
                                 playbackPluginUnload = playbackPluginResult;
-                                API.changeSource(sources[i]);
+                                API.changeActiveSource(sources[i]);
                                 break;
                             }
                         }
@@ -98,7 +99,7 @@ angular.module("com.2fdevs.videogular")
                         API.mediaElement.attr("src", sources[0].src);
                         API.mediaElement.attr("type", sources[0].type);
                         //Trigger vgChangeSource($source) API callback in vgController
-                        API.changeSource(sources[0]);
+                        API.changeActiveSource(sources[0]);
                     }
 
                     // Android 2.3 support: https://github.com/2fdevs/videogular/issues/187

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
@@ -20,64 +20,60 @@
  *
  */
 "use strict";
-angular.module("com.2fdevs.videogular.plugins.dash", [])
+angular.module("com.2fdevs.videogular.plugins.dash", ["com.2fdevs.videogular"])
+
+    .constant("VG_DASH_IS_SUPPORTED", (function(){
+        var dashCapabilitiesUtil = new MediaPlayer.utils.Capabilities();
+
+        return dashCapabilitiesUtil.supportsMediaSource();
+    })())
+
     .directive(
     "vgDash",
-    [function () {
+    ["VG_DASH_IS_SUPPORTED", function (VG_DASH_IS_SUPPORTED) {
         return {
             restrict: "A",
             require: "^videogular",
             link: function (scope, elem, attr, API) {
                 var context;
                 var player;
-                var dashCapabilitiesUtil = new MediaPlayer.utils.Capabilities();
-                var dashTypeRegEx = /^application\/dash\+xml/i;
 
                 //Proceed augmenting behavior only if the browser is capable of playing DASH (supports MediaSource Extensions)
-                if (dashCapabilitiesUtil.supportsMediaSource()) {
+                if (VG_DASH_IS_SUPPORTED) {
+                    scope.isDASH = function(src, type){
+                        var dashTypeRegEx = /^application\/dash\+xml/i;
+                        var hasDashType = dashTypeRegEx.test(type);
+                        var hasDashExtension = src.indexOf && (src.indexOf(".mpd") > 0);
 
-                    //Returns true if the source has the standard DASH type defined OR an .mpd extension.
-                    scope.isDASH = function isDASH(source) {
-                        var hasDashType = dashTypeRegEx.test(source.type);
-                        var hasDashExtension = source.src.indexOf && (source.src.indexOf(".mpd") > 0);
-
-                        return hasDashType || hasDashExtension;
+                        return hasDashType || hasDashExtension; //Returns true if the source has the standard DASH type defined OR an .mpd extension.
                     };
 
-                    scope.onSourceChange = function onSourceChange(source) {
-                        var url = source.src;
-
-                        // It's DASH, we use Dash.js
-                        if (scope.isDASH(source)) {
+                    scope.loadDashPlayer = function(src, type){
+                         if (src && scope.isDASH(src, type)) {
                             player = new MediaPlayer(new Dash.di.DashContext());
                             player.setAutoPlay(API.autoPlay);
                             player.startup();
                             player.attachView(API.mediaElement[0]);
-                            player.attachSource(url);
+                            player.attachSource(src);
+                            return scope.unloadDashPlayer;
                         }
-                        else if (player) {
-                            //not DASH, but the Dash.js player is still wired up
-                            //Dettach Dash.js from the mediaElement
-                            player.reset();
-                            player = null;
 
-                            //player.reset() wipes out the new url already applied, so have to reapply
-                            API.mediaElement.attr('src', url);
-                            API.stop();
+                        return false;
+                    };
+
+                    scope.unloadDashPlayer = function() {
+                        if (player) {
+                            //Dettach Dash.js from the mediaElement
+                            try {
+                                player.reset();
+                            } catch(ex){} //chomp
+                            player = null;
                         }
                     };
 
-                    scope.$watch(
-                        function () {
-                            return API.sources;
-                        },
-                        function (newVal, oldVal) {
-                            scope.onSourceChange(newVal[0]);
-                        }
-                    );
+                    API.registerPlaybackPlugin(scope.loadDashPlayer);
                 }
             }
         }
     }
     ]);
-

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
@@ -65,6 +65,7 @@ angular.module("com.2fdevs.videogular.plugins.dash", ["com.2fdevs.videogular"])
                         if (player) {
                             //Dettach Dash.js from the mediaElement
                             try {
+                                API.stop();
                                 player.reset();
                             } catch(ex){} //chomp
                             player = null;

--- a/test/spec/plugins/vg-dash.js
+++ b/test/spec/plugins/vg-dash.js
@@ -5,6 +5,7 @@ describe('Directive: DASH', function () {
     var $scope;
     var $compile;
     var VG_STATES;
+    var VG_DASH_IS_SUPPORTED;
 
     beforeEach(module('com.2fdevs.videogular'));
     beforeEach(module('com.2fdevs.videogular.plugins.dash'));
@@ -14,6 +15,7 @@ describe('Directive: DASH', function () {
         $scope = $injector.get('$rootScope').$new();
         $sce = $injector.get('$sce');
         VG_STATES = $injector.get('VG_STATES');
+        VG_DASH_IS_SUPPORTED = $injector.get('VG_DASH_IS_SUPPORTED');
 
         $scope.config = {
             preload: "none",
@@ -39,34 +41,32 @@ describe('Directive: DASH', function () {
 
     describe("DASH plugin - ", function () {
         it("should have been detected a DASH video", function () {
-            var dashCapabilitiesUtil = new MediaPlayer.utils.Capabilities();
-            var supportsDASH = dashCapabilitiesUtil.supportsMediaSource();
             var isDASH = false;
 
-            if (supportsDASH) {
+            if (VG_DASH_IS_SUPPORTED) {
                 var vgMedia = angular.element(element.find('[vg-dash]'));
                 var vgMediaScope = vgMedia.scope();
-                isDASH = vgMediaScope.isDASH($scope.config.sources[0]);
+                var source = $scope.config.sources[0];
+                isDASH = vgMediaScope.isDASH(source.src, source.type);
             }
 
-            expect(isDASH).toBe(supportsDASH);
+            expect(isDASH).toBe(VG_DASH_IS_SUPPORTED);
         });
 
         it("should have been changed a video source", function () {
-            var dashCapabilitiesUtil = new MediaPlayer.utils.Capabilities();
-            var supportsDASH = dashCapabilitiesUtil.supportsMediaSource();
             var isDASH = false;
             var vgMedia = angular.element(element.find('vg-media'));
 
-            if (supportsDASH) {
-                spyOn(vgMedia.scope(), "onSourceChange");
+            if (VG_DASH_IS_SUPPORTED) {
+                spyOn(vgMedia.scope(), "isDASH");
                 $scope.config.sources = [{src: "another_source.mpd", type: "application/dash+xml"}];
                 $scope.$digest();
 
-                expect(vgMedia.scope().onSourceChange).toHaveBeenCalledWith({src: "another_source.mpd", type: "application/dash+xml"});
+                expect(vgMedia.scope().isDASH).toHaveBeenCalledWith("another_source.mpd", "application/dash+xml");
+                expect(vgMedia.scope().isDASH).toBeTruthy();
             }
             else {
-                expect(vgMedia.scope().onSourceChange).toBeFalsy();
+                expect(vgMedia.scope().isDASH).toBeFalsy();
             }
         });
     });


### PR DESCRIPTION
Enhanced the core to better facilitate playback plugins to fix #302. Now they are part of the playback flow rather than having to compete with the vg core. Supports multiple playback plugins and allows for you to bounce between media types with ease.
* Native style src fall-through behavior. vg-media can play loop now attempts to play the given src using the available plugins.
* The basic structure for a playback plugin is to implement a loading function which accepts a src and type. If testing of the input reveals media it is capable of playing, it will be loaded up. An unloading function is then returned. You then simply register the plugin through API.registerPlaybackPlugin(loadingFunc). This is demonstrated in vg-dash. As you can see, it's pretty simple. The unloading function gets executed prior to applying a new src.
* Shouldn't break existing plugins.

<b>Other changes in here:</b>
1) Tracking of the actively used playback source, now available through API.activeSource.
2) A manual specification / override of isLive by including an isLive flag on your src object. Depending on the media type, this may not be possible to pull from the media or player. Fixes #303.
3) Safe apply throughout vg-controller using $applyAsync().
4) Found that multiple source changes were being picked up by vg-media, so took a stab at enhancing its checks in order to prevent the same source from being applied more than once.

