### PR TITLE
Normalized value for seek by percent so it can't fall out of valid range

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -318,6 +318,7 @@ angular.module("com.2fdevs.videogular")
             var second;
             if (byPercent) {
                 if (isVirtualClip) {
+                    value = Math.max(0, Math.min(value, 100));
                     second = (value * this.virtualClipDuration / 100);
                     this.mediaElement[0].currentTime = this.startTime + second;
                 }


### PR DESCRIPTION
When using hot keys to seek, the percent value can fall outside the valid range and cause visual defect when playhead seeks outside of progress bar bounds. 