### PR TITLE
Defensive check for mediaElement in clearMedia method

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -80,6 +80,10 @@ angular.module("com.2fdevs.videogular")
         this.videogularElement = null;
 
         this.clearMedia = function () {
+            if (typeof this.mediaElement === 'undefined' || typeof this.mediaElement[0] === 'undefined') {
+                return;
+            }
+
             this.mediaElement[0].src = '';
             this.mediaElement[0].removeEventListener("canplay", this.onCanPlay.bind(this), false);
             this.mediaElement[0].removeEventListener("loadedmetadata", this.onLoadMetaData.bind(this), false);


### PR DESCRIPTION
Prevents errors from being thrown upon calling clearMedia() when mediaElement doesn't exist. This can be the case when some form of deferred loading of vg-media has been implemented where mediaElement might not always be initialised.