### PR TITLE
Update vg-controller.js

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -80,10 +80,6 @@ angular.module("com.2fdevs.videogular")
         this.videogularElement = null;
 
         this.clearMedia = function () {
-            if (typeof this.mediaElement === 'undefined' || typeof this.mediaElement[0] === 'undefined') {
-                return;
-            }
-
             this.mediaElement[0].src = '';
             this.mediaElement[0].removeEventListener("canplay", this.onCanPlay.bind(this), false);
             this.mediaElement[0].removeEventListener("loadedmetadata", this.onLoadMetaData.bind(this), false);
@@ -557,6 +553,7 @@ angular.module("com.2fdevs.videogular")
             this.isFullScreen = false;
             this.playback = 1;
             this.isConfig = ($scope.vgConfig != undefined);
+            this.mediaElement = [{play:function(){}, pause:function(){}, stop:function(){}, addEventListener:function(){}, removeEventListener: function(){}}];
 
             if (vgFullscreen.isAvailable) {
                 this.isFullScreen = vgFullscreen.isFullScreen();


### PR DESCRIPTION
The autoplay watcher $scope.$watch("vgAutoPlay", this.onUpdateAutoPlay.bind(this)); immediately runs onUpdateAutoPlay which runs play, while the mediaElement is not yet initialized by the vgMedia directive. Resulting in an error stating: "mediaElement[0] undefined".  

This commit adds a mediaElement[0] stub which is overwritten when the real mediaElement is initialized. (This also solves the clearMedia undefined error).