### PR TITLE
Put the obtaining a sessionStorage under the try-catch block

### DIFF
--- a/app/scripts/com/2fdevs/videogular/services/vg-utils.js
+++ b/app/scripts/com/2fdevs/videogular/services/vg-utils.js
@@ -66,9 +66,9 @@ angular.module("com.2fdevs.videogular")
          */
         this.supportsLocalStorage = function () {
             var testKey = 'videogular-test-key';
-            var storage = $window.sessionStorage;
 
             try {
+                var storage = $window.sessionStorage;
                 storage.setItem(testKey, '1');
                 storage.removeItem(testKey);
                 return 'localStorage' in $window && $window['localStorage'] !== null;

--- a/test/spec/services/vg-utls.js
+++ b/test/spec/services/vg-utls.js
@@ -1,0 +1,30 @@
+'use strict';
+describe('Directive: Videogular Utils', function () {
+
+  beforeEach(module('com.2fdevs.videogular'));
+
+  var VG_UTILS;
+  beforeEach(inject(function (_VG_UTILS_) {
+    VG_UTILS = _VG_UTILS_;
+  }));
+
+  describe("supportsLocalStorage - ", function() {
+    it('should return false if sessionStorage unrichable', inject(function ($window) {
+
+      // Emulate browser restrictions
+      Object.defineProperty($window, 'sessionStorage', {
+        get: function () {
+          throw new Error('Access is denied');
+        }
+      });
+
+      var fn = function () {
+        VG_UTILS.supportsLocalStorage();
+      };
+
+      expect(fn).not.toThrow();
+      expect(VG_UTILS.supportsLocalStorage()).toBe(false);
+    }));
+  });
+
+});


### PR DESCRIPTION
Solve this problem: When "Block third-party cookies and site data" on chrome://settings/content is enabled and videogular embeded as iframe than the player throws "Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document."