### PR TITLE
poster plugin img role presentation for accessibility

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
@@ -27,7 +27,7 @@ angular.module("com.2fdevs.videogular.plugins.poster", [])
     .run(
     ["$templateCache", function ($templateCache) {
         $templateCache.put("vg-templates/vg-poster",
-            '<img ng-src="{{vgUrl}}" ng-class="API.currentState" role="presentation" alt="video poster">');
+            '<img ng-src="{{vgUrl}}" ng-class="API.currentState" role="presentation" alt="">');
     }]
 )
     .directive("vgPoster",

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
@@ -27,7 +27,7 @@ angular.module("com.2fdevs.videogular.plugins.poster", [])
     .run(
     ["$templateCache", function ($templateCache) {
         $templateCache.put("vg-templates/vg-poster",
-            '<img ng-src="{{vgUrl}}" ng-class="API.currentState">');
+            '<img ng-src="{{vgUrl}}" ng-class="API.currentState" role="presentation">');
     }]
 )
     .directive("vgPoster",

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-poster/vg-poster.js
@@ -27,7 +27,7 @@ angular.module("com.2fdevs.videogular.plugins.poster", [])
     .run(
     ["$templateCache", function ($templateCache) {
         $templateCache.put("vg-templates/vg-poster",
-            '<img ng-src="{{vgUrl}}" ng-class="API.currentState" role="presentation">');
+            '<img ng-src="{{vgUrl}}" ng-class="API.currentState" role="presentation" alt="video poster">');
     }]
 )
     .directive("vgPoster",

--- a/test/spec/plugins/vg-poster.js
+++ b/test/spec/plugins/vg-poster.js
@@ -53,4 +53,12 @@ describe('Directive: Poster', function () {
       expect(img.attr("src")).toBe("assets/images/videogular.png");
 		});
   });
+
+	describe("Element attributes -", function() {
+		it("should have a role attribute", function() {
+			var img = element.find("img");
+
+      expect(img.attr("role")).toBe("presentation");
+		});
+  });
 });


### PR DESCRIPTION
because the poster img (image) is for presentation purposes and this change solves an accessibility issue where accessibility auditors require all img tags to have either an "alt" attribute or role="presentation".