### PR TITLE
Source can be a simple URL string

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -18,7 +18,7 @@
  * - toggleFullScreen(): Toggles between fullscreen and normal mode.
  * - updateTheme(css-url): Removes previous CSS theme and sets a new one.
  * - clearMedia(): Cleans the current media file.
- * - changeSource(array): Updates current media source. Param `array` must be an array of media source objects.
+ * - changeSource(array): Updates current media source. Param `array` must be an array of media source objects or a simple URL string.
  * A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
  * <pre>{src: $sce.trustAsResourceUrl("http://static.videogular.com/assets/videos/videogular.mp4"), type: "video/mp4"}</pre>
  *
@@ -32,7 +32,7 @@
  * - nativeFullscreen: Boolean value to know if Videogular if fullscreen mode will use native mode or emulated mode.
  * - mediaElement: Reference to video/audio object.
  * - videogularElement: Reference to videogular tag.
- * - sources: Array with current sources.
+ * - sources: Array with current sources or a simple URL string.
  * - tracks: Array with current tracks.
  * - cuePoints: Object containing a list of timelines with cue points. Each property in the object represents a timeline, which is an Array of objects with the next definition:
  * <pre>{

--- a/app/scripts/com/2fdevs/videogular/directives/vg-media.js
+++ b/app/scripts/com/2fdevs/videogular/directives/vg-media.js
@@ -5,7 +5,7 @@
  * @description
  * Directive to add a source of videos or audios. This directive will create a &lt;video&gt; or &lt;audio&gt; tag and usually will be above plugin tags.
  *
- * @param {array} vgSrc Bindable array with a list of media sources. A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
+ * @param {array} vgSrc Bindable array with a list of media sources or a simple url string. A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
  * @param {string} vgType String with "video" or "audio" values to set a <video> or <audio> tag inside <vg-media>.
  * <pre>
  * {
@@ -56,31 +56,37 @@ angular.module("com.2fdevs.videogular")
                 };
 
                 scope.changeSource = function changeSource() {
-                    var canPlay = "";
 
-                    // It's a cool browser
-                    if (API.mediaElement[0].canPlayType) {
-                        for (var i = 0, l = sources.length; i < l; i++) {
-                            canPlay = API.mediaElement[0].canPlayType(sources[i].type);
+                    if (angular.isArray(sources)) {
+                        var canPlay = "";
 
-                            if (canPlay == "maybe" || canPlay == "probably") {
-                                API.mediaElement.attr("src", sources[i].src);
-                                API.mediaElement.attr("type", sources[i].type);
-                                //Trigger vgChangeSource($source) API callback in vgController
-                                API.changeSource(sources[i]);
-                                break;
+                        // It's a cool browser
+                        if (API.mediaElement[0].canPlayType) {
+                            for (var i = 0, l = sources.length; i < l; i++) {
+                                canPlay = API.mediaElement[0].canPlayType(sources[i].type);
+
+                                if (canPlay == "maybe" || canPlay == "probably") {
+                                    API.mediaElement.attr("src", sources[i].src);
+                                    API.mediaElement.attr("type", sources[i].type);
+                                    //Trigger vgChangeSource($source) API callback in vgController
+                                    API.changeSource(sources[i]);
+                                    break;
+                                }
                             }
                         }
-                    }
-                    // It's a crappy browser and it doesn't deserve any respect
-                    else {
-                        // Get H264 or the first one
-                        API.mediaElement.attr("src", sources[0].src);
-                        API.mediaElement.attr("type", sources[0].type);
+                        // It's a crappy browser and it doesn't deserve any respect
+                        else {
+                            // Get H264 or the first one
+                            API.mediaElement.attr("src", sources[0].src);
+                            API.mediaElement.attr("type", sources[0].type);
+                            //Trigger vgChangeSource($source) API callback in vgController
+                            API.changeSource(sources[0]);
+                        }
+                    } else {
+                        API.mediaElement.attr("src", sources);
                         //Trigger vgChangeSource($source) API callback in vgController
-                        API.changeSource(sources[0]);
+                        API.changeSource(sources);
                     }
-
                     // Android 2.3 support: https://github.com/2fdevs/videogular/issues/187
                     if (VG_UTILS.isMobileDevice()) API.mediaElement[0].load();
 


### PR DESCRIPTION
Enable the possibility to provide a single URL string as source for the video player. This can be very convenient in some cases.