### PR TITLE
Events, vg-dash fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -249,6 +249,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-ngdocs');
 
     grunt.registerTask('default', ['karma:test', 'clean:build', 'cssmin:css', 'concat', 'uglify:js', 'copy:main', 'copy:release']);
+    grunt.registerTask('buildOnly', ['clean:build', 'cssmin:css', 'concat', 'uglify:js', 'copy:main', 'copy:release']);
     grunt.registerTask('docs', ['clean:docs', 'ngdocs']);
     grunt.registerTask('test', ['karma:test']);
     grunt.registerTask('major-release', ['default', 'hub:major']);

--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -104,6 +104,9 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onCanPlay = function (evt) {
+            $scope.$emit('vgCanPlay', {
+                vgName: $scope.vgName
+            });
             this.isBuffering = false;
             $scope.$parent.$digest($scope.vgCanPlay({$event: evt}));
 
@@ -114,6 +117,9 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onVideoReady = function () {
+            $scope.$emit('vgVideoReady', {
+                vgName: $scope.vgName
+            });
             this.isReady = true;
             this.autoPlay = $scope.vgAutoPlay;
             this.playsInline = $scope.vgPlaysInline;
@@ -160,6 +166,9 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onLoadMetaData = function (evt) {
+            $scope.$emit('vgLoadedMetadata', {
+                vgName: $scope.vgName
+            });
             this.isBuffering = false;
             this.onUpdateTime(evt);
         };
@@ -279,11 +288,17 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onPlay = function () {
+            $scope.$emit('vgPlay', {
+                vgName: $scope.vgName
+            });
             this.setState(VG_STATES.PLAY);
             $scope.$parent.$digest();
         };
 
         this.onPause = function () {
+            $scope.$emit('vgPause', {
+                vgName: $scope.vgName
+            });
             var currentTime = isVirtualClip ? this.currentTime : this.mediaElement[0].currentTime;
 
             if (currentTime == 0) {
@@ -298,6 +313,10 @@ angular.module("com.2fdevs.videogular")
 
         this.onVolumeChange = function () {
             this.volume = this.mediaElement[0].volume;
+            $scope.$emit('vgVolumeChange', {
+                vgName: $scope.vgName,
+                volume: this.volume
+            });
             $scope.$parent.$digest();
         };
 
@@ -498,16 +517,25 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onStartBuffering = function (event) {
+            $scope.$emit('vgStartBuffering', {
+                vgName: $scope.vgName
+            });
             this.isBuffering = true;
             $scope.$parent.$digest();
         };
 
         this.onStartPlaying = function (event) {
+            $scope.$emit('vgStartPlaying', {
+                vgName: $scope.vgName
+            });
             this.isBuffering = false;
             $scope.$parent.$digest();
         };
 
         this.onComplete = function (event) {
+            $scope.$emit('vgComplete', {
+                vgName: $scope.vgName
+            });
             $scope.vgComplete();
 
             this.setState(VG_STATES.STOP);
@@ -521,6 +549,10 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onVideoError = function (event) {
+            $scope.$emit('vgError', {
+                vgName: $scope.vgName,
+                $event: event
+            });
             $scope.vgError({$event: event});
         };
 

--- a/app/scripts/com/2fdevs/videogular/directives/videogular.js
+++ b/app/scripts/com/2fdevs/videogular/directives/videogular.js
@@ -139,7 +139,8 @@ angular.module("com.2fdevs.videogular")
                 vgChangeSource: "&",
                 vgSeeking: "&",
                 vgSeeked: "&",
-                vgError: "&"
+                vgError: "&",
+                vgName: "@"
             },
             controller: "vgController",
             controllerAs: "API",

--- a/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-dash/vg-dash.js
@@ -47,32 +47,37 @@ angular.module("com.2fdevs.videogular.plugins.dash", [])
                     };
 
                     scope.onSourceChange = function onSourceChange(source) {
-                        var url = source.src;
+                        if (source && source.src) {
+                            var url = source.src;
 
-                        // It's DASH, we use dash.js
-                        if (scope.isDASH(source)) {
-                            if (angular.isFunction(dashjs && dashjs.MediaPlayer)) {
-                                // dash.js version 2.x
-                                player = dashjs.MediaPlayer().create();
-                                player.initialize(API.mediaElement[0], url, API.autoPlay);
-                            } else {
-                                // dash.js version < 2.x
-                                player = new MediaPlayer(new Dash.di.DashContext());
-                                player.setAutoPlay(API.autoPlay);
-                                player.startup();
-                                player.attachView(API.mediaElement[0]);
-                                player.attachSource(url);
+                            // It's DASH, we use dash.js
+                            if (scope.isDASH(source)) {
+                                if (angular.isFunction(dashjs && dashjs.MediaPlayer)) {
+                                    // dash.js version 2.x
+                                    player = dashjs.MediaPlayer().create();
+                                    player.initialize(API.mediaElement[0], url, (API.autoPlay !== undefined) ? API.autoPlay : false);
+                                    if (attr['dashSilence'] && attr['dashSilence'] != "false") {
+                                        player.getDebug().setLogToBrowserConsole(false);
+                                    }
+                                } else {
+                                    // dash.js version < 2.x
+                                    player = new MediaPlayer(new Dash.di.DashContext());
+                                    player.setAutoPlay(API.autoPlay);
+                                    player.startup();
+                                    player.attachView(API.mediaElement[0]);
+                                    player.attachSource(url);
+                                }
                             }
-                        }
-                        else if (player) {
-                            //not DASH, but the dash.js player is still wired up
-                            //Dettach dash.js from the mediaElement
-                            player.reset();
-                            player = null;
+                            else if (player) {
+                                //not DASH, but the dash.js player is still wired up
+                                //Dettach dash.js from the mediaElement
+                                player.reset();
+                                player = null;
 
-                            //player.reset() wipes out the new url already applied, so have to reapply
-                            API.mediaElement.attr('src', url);
-                            API.stop();
+                                //player.reset() wipes out the new url already applied, so have to reapply
+                                API.mediaElement.attr('src', url);
+                                API.stop();
+                            }
                         }
                     };
 


### PR DESCRIPTION
This patch includes:

- Add $scope.$emit events for consumption elsewhere by angular
- Improvements to vg-dash: 
       Ensure source is valid before attempting to process it
       Add "dash-silence" attribute to squish dash.js console spam
       dashjs considers autoplay == undefined to mean TRUE - correct this