### PR TITLE
added custom action to vg-analytics

### DIFF
--- a/test/spec/plugins/vg-analytics.js
+++ b/test/spec/plugins/vg-analytics.js
@@ -4,120 +4,241 @@ describe('Directive: Analytics', function () {
   var analytics;
   var API;
   var $sce;
-	var $scope;
-	var $compile;
-	var VG_STATES;
+  var $scope;
+  var $compile;
+  var VG_STATES;
 
-	beforeEach(module('com.2fdevs.videogular'));
-	beforeEach(module('com.2fdevs.videogular.plugins.analytics'));
+  beforeEach(module('com.2fdevs.videogular'));
+  beforeEach(module('com.2fdevs.videogular.plugins.analytics'));
 
-	beforeEach(inject(function ($injector) {
-    $compile = $injector.get('$compile');
-    $scope = $injector.get('$rootScope').$new();
-    $sce = $injector.get('$sce');
-    VG_STATES = $injector.get('VG_STATES');
+  describe('Test simple configuration', function () {
+    beforeEach(inject(function ($injector) {
+      $compile = $injector.get('$compile');
+      $scope = $injector.get('$rootScope').$new();
+      $sce = $injector.get('$sce');
+      VG_STATES = $injector.get('VG_STATES');
 
-    $scope.config = {
-      preload: "none",
-      controls: true,
-      loop: true,
-      sources: [
-        {src: $sce.trustAsResourceUrl("assets/videos/videogular.mp4"), type: "video/mp4"},
-        {src: $sce.trustAsResourceUrl("assets/videos/videogular.webm"), type: "video/webm"},
-        {src: $sce.trustAsResourceUrl("assets/videos/videogular.ogg"), type: "video/ogg"}
-      ],
-      theme: {
-        url: "styles/themes/default/videogular.css"
-      },
-      plugins: {
-        analytics: {
-          category: "Videogular",
-          label: "Main",
-          events: {
-            ready: true,
-            play: true,
-            pause: true,
-            stop: true,
-            complete: true,
-            progress: 10
+      $scope.config = {
+        preload: "none",
+        controls: true,
+        loop: true,
+        sources: [
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.mp4"), type: "video/mp4" },
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.webm"), type: "video/webm" },
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.ogg"), type: "video/ogg" }
+        ],
+        theme: {
+          url: "styles/themes/default/videogular.css"
+        },
+        plugins: {
+          analytics: {
+            category: "Videogular",
+            label: "Main",
+            events: {
+              ready: true,
+              play: true,
+              pause: true,
+              stop: true,
+              complete: true,
+              progress: 10
+            }
           }
         }
-      }
-    };
+      };
 
-		element = angular.element(
-      '<videogular vg-theme="config.theme.url">' +
+      element = angular.element(
+        '<videogular vg-theme="config.theme.url">' +
         '<vg-media vg-src="config.sources"></vg-media>' +
         '<vg-analytics vg-track-info="config.plugins.analytics"></vg-analytics>' +
-      '</videogular>'
-    );
+        '</videogular>'
+      );
 
-    $compile(element)($scope);
+      $compile(element)($scope);
 
-    analytics = element.find("vg-analytics");
-    API = element.isolateScope().API;
-	}));
+      analytics = element.find("vg-analytics");
+      API = element.isolateScope().API;
+    }));
 
-	describe("Track ready - ", function() {
-		it("should track ready event", function() {
-      spyOn(analytics.isolateScope(), "trackEvent");
-      $scope.$digest();
+    describe("Track ready - ", function () {
+      it("should track ready event", function () {
+        spyOn(analytics.isolateScope(), "trackEvent");
+        $scope.$digest();
 
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("ready");
-		});
-  });
-
-  describe("Track State - ", function() {
-		it("should track state change event on play", function() {
-      $scope.$digest();
-      spyOn(analytics.isolateScope(), "trackEvent");
-      API.play();
-      $scope.$digest();
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("play");
-		});
-
-    it("should track state change event on pause", function() {
-      $scope.$digest();
-      spyOn(analytics.isolateScope(), "trackEvent");
-      API.pause();
-      $scope.$digest();
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("pause");
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("ready");
+      });
     });
 
-    // TODO: Firefox throws an error at API.stop() because API.mediaElement[0].currentTime doesn't exists
-    xit("should track state change event on stop", function() {
-      $scope.$digest();
-      API.play();
-      $scope.$digest();
-      spyOn(analytics.isolateScope(), "trackEvent");
-      API.stop();
-      $scope.$digest();
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("stop");
+    describe("Track State - ", function () {
+      it("should track state change event on play", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.play();
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("play");
+      });
+
+      it("should track state change event on pause", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.pause();
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("pause");
+      });
+
+      // TODO: Firefox throws an error at API.stop() because API.mediaElement[0].currentTime doesn't exists
+      xit("should track state change event on stop", function () {
+        $scope.$digest();
+        API.play();
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.stop();
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("stop");
+      });
     });
+
+    describe("Track Complete State - ", function () {
+      it("should track complete event", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.isCompleted = true;
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("complete");
+      });
+    });
+
+    describe("Track Update Time - ", function () {
+      it("should track update time at 10% event", function () {
+        $scope.$digest();
+
+        API.totalTime = new Date(10000);
+        $scope.$digest();
+
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.currentTime = new Date(1100);
+        $scope.$digest();
+
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("progress 10%");
+      });
+    });
+
   });
+  describe('Test advanced configuration', function () {
 
-  describe("Track Complete State - ", function() {
-		it("should track complete event", function() {
-      $scope.$digest();
-      spyOn(analytics.isolateScope(), "trackEvent");
-      API.isCompleted = true;
-      $scope.$digest();
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("complete");
-		});
-  });
+    beforeEach(inject(function ($injector) {
+      $compile = $injector.get('$compile');
+      $scope = $injector.get('$rootScope').$new();
+      $sce = $injector.get('$sce');
+      VG_STATES = $injector.get('VG_STATES');
 
-  describe("Track Update Time - ", function() {
-		it("should track update time at 10% event", function() {
-      $scope.$digest();
+      $scope.config = {
+        preload: "none",
+        controls: true,
+        loop: true,
+        sources: [
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.mp4"), type: "video/mp4" },
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.webm"), type: "video/webm" },
+          { src: $sce.trustAsResourceUrl("assets/videos/videogular.ogg"), type: "video/ogg" }
+        ],
+        theme: {
+          url: "styles/themes/default/videogular.css"
+        },
+        plugins: {
+          analytics: {
+            category: "Videogular",
+            label: "Main",
+            events: {
+              ready: { action: 'custom.ready' },
+              play: { value: 'percent', action: 'custom.play' },
+              pause: { action: 'custom.pause' },
+              stop: { action: 'custom.stop' },
+              complete: { action: 'custom.complete' },
+              progress: { value: 10, action: 'custom.progress' }
+            }
+          }
+        }
+      };
 
-      API.totalTime = new Date(10000);
-      $scope.$digest();
+      element = angular.element(
+        '<videogular vg-theme="config.theme.url">' +
+        '<vg-media vg-src="config.sources"></vg-media>' +
+        '<vg-analytics vg-track-info="config.plugins.analytics"></vg-analytics>' +
+        '</videogular>'
+      );
 
-      spyOn(analytics.isolateScope(), "trackEvent");
-      API.currentTime = new Date(1100);
-      $scope.$digest();
+      $compile(element)($scope);
 
-      expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("progress 10%");
-		});
+      analytics = element.find("vg-analytics");
+      API = element.isolateScope().API;
+    }));
+
+    describe("Track ready - ", function () {
+      it("should track ready event", function () {
+        spyOn(analytics.isolateScope(), "trackEvent");
+        $scope.$digest();
+
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.ready");
+      });
+    });
+
+    describe("Track State - ", function () {
+      it("should track state change event on play", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "setValue");
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.play();
+        $scope.$digest();
+        expect(analytics.isolateScope().setValue).toHaveBeenCalledWith({
+          value: 'percent',
+          action: 'custom.play'
+        });
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.play");
+      });
+
+      it("should track state change event on pause", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.pause();
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.pause");
+      });
+
+      // TODO: Firefox throws an error at API.stop() because API.mediaElement[0].currentTime doesn't exists
+      xit("should track state change event on stop", function () {
+        $scope.$digest();
+        API.play();
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.stop();
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.stop");
+      });
+    });
+
+    describe("Track Complete State - ", function () {
+      it("should track complete event", function () {
+        $scope.$digest();
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.isCompleted = true;
+        $scope.$digest();
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.complete");
+      });
+    });
+
+    describe("Track Update Time - ", function () {
+      it("should track update time at 10% event", function () {
+        $scope.$digest();
+
+        API.totalTime = new Date(10000);
+        $scope.$digest();
+
+        spyOn(analytics.isolateScope(), "trackEvent");
+        API.currentTime = new Date(1100);
+        $scope.$digest();
+
+        expect(analytics.isolateScope().trackEvent).toHaveBeenCalledWith("custom.progress 10%");
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Hi, 
I'm working on a project where I introduced videogular. I currently setting up event tracking for the project so I decided to give a try to the vg-analytics plugin. 

In my case I need to specify the action names for the events in the application. vg-analytics does not support it, this is why I'm creating this pull request. 

In the code I introduced the possibility to pass a configuration object as `vgTrackInfo`. There are also some new test to verify this scenario. 

As an example: 
```
var playerConfig = {
  ...
  plugins: {
    analytics: {
      category: "Videogular",
      label: "Main",
      events: {
        ready: { action: 'customReady' },
        play: { value: 'percent', action: 'customPlay' },
        pause: { value: 'percent', action: 'customPause' },
        stop: { value: 'percent', action: 'customStop' },
        complete: { action: 'customComplete' },
        progress: { value: 10, action: 'customProgress' }
      }
    }
  }
};
```