### PR TITLE
Native play blacklist

### DIFF
--- a/test/spec/directives/videogular.js
+++ b/test/spec/directives/videogular.js
@@ -20,6 +20,7 @@ describe('Directive: Videogular', function () {
             preload: "none",
             controls: true,
             loop: true,
+            nativePlayBlacklist: null,
             sources: [
                 {src: $sce.trustAsResourceUrl("assets/videos/videogular.mp4"), type: "video/mp4"},
                 {src: $sce.trustAsResourceUrl("assets/videos/videogular.webm"), type: "video/webm"},
@@ -47,7 +48,7 @@ describe('Directive: Videogular', function () {
 
         element = angular.element(
             '<videogular vg-theme="config.theme.url">' +
-            '<vg-media vg-src="config.sources" vg-tracks="config.tracks" vg-native-controls="config.controls" vg-preload="config.preload" vg-loop="config.loop"></vg-media>' +
+            '<vg-media vg-src="config.sources" vg-tracks="config.tracks" vg-native-controls="config.controls" vg-preload="config.preload" vg-loop="config.loop" vg-native-play-blacklist="config.nativePlayBlacklist"></vg-media>' +
             '</videogular>'
         );
 
@@ -154,6 +155,46 @@ describe('Directive: Videogular', function () {
             API.setVolume(0.5);
             expect(video.volume).toBe(0.5);
             expect(API.volume).toBe(0.5);
+        });
+    });
+
+    describe("vgNativePlayBlacklist - ", function() {
+        function updateSources(API) {
+            API.sources = angular.copy(API.sources);
+            $scope.$apply();
+        }
+
+        it("should handle an empty array", function() {
+            var API = element.isolateScope().API;
+            var video = API.mediaElement;
+
+            spyOn(API, "changeSource");
+
+            $scope.config.nativePlayBlacklist = [];
+            updateSources(API);
+
+            
+            expect(API.changeSource).toHaveBeenCalledWith(jasmine.objectContaining({type: "video/mp4"}));
+
+            expect(video.attr("src")).toBe("assets/videos/videogular.mp4");
+        });
+
+        it("should blacklist mp4", function(){
+            var API = element.isolateScope().API;
+            var video = API.mediaElement;
+
+            spyOn(API, "changeSource");
+
+            $scope.config.nativePlayBlacklist = [
+                function blacklistMp4(source, userAgent) {
+                    //expect source and userAgent to be defined
+                    return source.type === 'video/mp4';
+                }
+            ];
+            updateSources(API);
+            
+            expect(API.changeSource).not.toHaveBeenCalledWith(jasmine.objectContaining({type: "video/mp4"}));
+            expect(video.attr("src")).not.toBe("assets/videos/videogular.mp4");
         });
     });
 });


### PR DESCRIPTION
- You may now supply **vgNativePlayBlacklist** on **vgMedia** to prevent native playback of sources as
desired. It expects an array of functions accepting  the media source and user agent. If any of
these return true,  native playback will not be attempted. This  may be useful in combination with
playback plugins. For example, you may want to use hls.js  in Android Chrome rather than its native
handling.
- Some clean up of **changeSource()** while I was in there. I found that it wasn't consistent across the various sources cases. The post-apply behavior has also been refined to run only when you've actually applied a source or fire an error if it couldn't. Should be easier to follow.