### PR TITLE
Fix for wrong firing of `cuePoint.onComplete` when cuePoints list changed

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -615,7 +615,7 @@ angular.module("com.2fdevs.videogular")
 
         this.onUpdateCuePoints = function onUpdateCuePoints(newValue) {
             this.cuePoints = newValue;
-            this.checkCuePoints(this.currentTime);
+            this.checkCuePoints(this.currentTime / 1000);
         };
 
         this.onUpdateClearMediaOnNavigate = function onUpdateClearMediaOnNavigate(newValue) {


### PR DESCRIPTION
Fix for #459 
