### PR TITLE
Small fixes + enhancements round 1

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -315,6 +315,10 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.seekTime = function (value, byPercent) {
+            if (!Number.isFinite(value)) {
+                throw new TypeError('Expecting a finite number value.');
+            }
+
             var second;
             if (byPercent) {
                 if (isVirtualClip) {

--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -19,7 +19,7 @@
  * - updateTheme(css-url): Removes previous CSS theme and sets a new one.
  * - clearMedia(): Cleans the current media file.
  * - changeSource(array): Updates current media source. Param `array` must be an array of media source objects.
- * A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
+ * A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource. You may explicitly supply an `isLive` flag to override automatic detection.
  * <pre>{src: $sce.trustAsResourceUrl("http://static.videogular.com/assets/videos/videogular.mp4"), type: "video/mp4"}</pre>
  *
  * Properties
@@ -184,6 +184,7 @@ angular.module("com.2fdevs.videogular")
 
         this.onUpdateTime = function (event) {
             var targetTime = 1000 * event.target.currentTime;
+            var isLiveSourceOverride = this.activeSource && angular.isDefined(this.activeSource.isLive);
 
             this.updateBuffer(event);
 
@@ -211,6 +212,11 @@ angular.module("com.2fdevs.videogular")
                 // It's a live streaming without and end
                 this.currentTime = targetTime;
                 this.isLive = true;
+            }
+
+            // allow for the user to override the built in live detection for cases where it doesn't work as desired
+            if (isLiveSourceOverride) {
+                this.isLive = !!this.activeSource.isLive;
             }
 
             var targetSeconds = isVirtualClip ? this.currentTime / 1000 : event.target.currentTime;
@@ -473,6 +479,11 @@ angular.module("com.2fdevs.videogular")
 
         this.changeSource = function (newValue) {
             this.activeSource = newValue;
+
+            if (angular.isDefined(newValue.isLive)) {
+                this.isLive = !!newValue.isLive;
+            }
+
             $scope.vgChangeSource({$source: newValue});
         };
 

--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -33,6 +33,7 @@
  * - mediaElement: Reference to video/audio object.
  * - videogularElement: Reference to videogular tag.
  * - sources: Array with current sources or a simple URL string.
+ * - activeSource: The source presently applied to the media element.
  * - tracks: Array with current tracks.
  * - cuePoints: Object containing a list of timelines with cue points. Each property in the object represents a timeline, which is an Array of objects with the next definition:
  * <pre>{
@@ -471,6 +472,7 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.changeSource = function (newValue) {
+            this.activeSource = newValue;
             $scope.vgChangeSource({$source: newValue});
         };
 

--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -18,7 +18,7 @@
  * - toggleFullScreen(): Toggles between fullscreen and normal mode.
  * - updateTheme(css-url): Removes previous CSS theme and sets a new one.
  * - clearMedia(): Cleans the current media file.
- * - changeSource(array): Updates current media source. Param `array` must be an array of media source objects or a simple URL string.
+ * - changeSource(array): Updates current media source. Param `array` must be an array of media source objects.
  * A media source is an object with two properties `src` and `type`. The `src` property must contains a trustful url resource.
  * <pre>{src: $sce.trustAsResourceUrl("http://static.videogular.com/assets/videos/videogular.mp4"), type: "video/mp4"}</pre>
  *
@@ -32,7 +32,7 @@
  * - nativeFullscreen: Boolean value to know if Videogular if fullscreen mode will use native mode or emulated mode.
  * - mediaElement: Reference to video/audio object.
  * - videogularElement: Reference to videogular tag.
- * - sources: Array with current sources or a simple URL string.
+ * - sources: Array with current sources.
  * - activeSource: The source presently applied to the media element.
  * - tracks: Array with current tracks.
  * - cuePoints: Object containing a list of timelines with cue points. Each property in the object represents a timeline, which is an Array of objects with the next definition:

--- a/test/spec/directives/videogular.js
+++ b/test/spec/directives/videogular.js
@@ -227,4 +227,19 @@ describe('Directive: Videogular', function () {
             expect(video.attr("src")).not.toBe("assets/videos/videogular.mp4");
         });
     });
+
+    describe("Source isLive override - ", function() {
+        it("should apply the isLive source override correctly", function() {
+            var API = element.isolateScope().API;
+
+            API.sources = API.sources.map(function(source) {
+                source.isLive = true;
+
+                return source;
+            }); 
+            $scope.$apply();
+
+            expect(API.isLive).toBe(true);
+        });
+    });
 });

--- a/test/spec/directives/videogular.js
+++ b/test/spec/directives/videogular.js
@@ -156,6 +156,16 @@ describe('Directive: Videogular', function () {
             expect(video.volume).toBe(0.5);
             expect(API.volume).toBe(0.5);
         });
+
+        it("should throw an error on an invalid seek time", function() {
+            var API = element.isolateScope().API;
+
+            function invalidSeek() {
+                return API.seekTime(Number.Infinity);
+            }
+
+            expect(invalidSeek).toThrowError(TypeError);
+        });
     });
 
     describe("Boolean configuration - ", function() {

--- a/test/spec/directives/videogular.js
+++ b/test/spec/directives/videogular.js
@@ -101,6 +101,12 @@ describe('Directive: Videogular', function () {
     });
 
     describe("API - ", function () {
+        it("should convey the activeSource", function(){
+            var API = element.isolateScope().API;
+
+            expect(API.activeSource).toBe(API.sources[0]);
+        });
+
         it("should play mediaElement on call API.play", function () {
             var API = element.isolateScope().API;
             var video = API.mediaElement[0];


### PR DESCRIPTION
### Description
1. Add input validation to seekTime() to ensure that it only accepts finite numbers.
1. Safer handling of play() and pause() to silence some console noise. Some browsers have async methods and will complain when you interrupt an operation.
1. New _API.activeSource_ to provide convenient access to the applied source. There's presently an event to expose this to the outside, but no convenient way to get to it internally.
1. Fix to the doc comments about expected source input. String not supported.
1. Add support for a new optional _isLive_ flag on the source input object. This allows you to override the built in detection logic, which may not be reliable in all cases such as with playback plugins.