### PR TITLE
Correct ngPlaybackButton name in its comments

### DIFF
--- a/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
+++ b/app/scripts/com/2fdevs/videogular/plugins/vg-controls/vg-playback-button/vg-playback-button.js
@@ -1,6 +1,6 @@
 /**
  * @ngdoc directive
- * @name com.2fdevs.videogular.plugins.controls.directive:ngPlaybackButton
+ * @name com.2fdevs.videogular.plugins.controls.directive:vgPlaybackButton
  * @restrict E
  * @description
  * Directive to display a playback buttom to control the playback rate.


### PR DESCRIPTION
### Description
docs(vgPlaybackButton): Correct a typo in the inline doc for vgPlaybackButton where it is mistakenly

Fixes #422.
