### PR TITLE
vgSeeking - convey seek time more reliably

### DIFF
--- a/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
+++ b/app/scripts/com/2fdevs/videogular/controllers/vg-controller.js
@@ -317,7 +317,11 @@ angular.module("com.2fdevs.videogular")
         };
 
         this.onSeeking = function (event) {
-            $scope.vgSeeking({$currentTime: event.target.currentTime, $duration: event.target.duration});
+            var currentTime = angular.isNumber(this.seekStartTime) ? this.seekStartTime : event.target.currentTime;
+
+            $scope.vgSeeking({$currentTime: currentTime, $duration: event.target.duration});
+
+            this.seekStartTime = null;
         };
 
         this.onSeeked = function (event) {
@@ -328,6 +332,8 @@ angular.module("com.2fdevs.videogular")
             if (!Number.isFinite(value)) {
                 throw new TypeError('Expecting a finite number value.');
             }
+
+            this.seekStartTime = this.currentTime / 1000; // ms to sec
 
             var second;
             if (byPercent) {


### PR DESCRIPTION
### Description
 Convey the vgSeeking $currentTime from the seekTime() value.

Due to timing, the native seeking event does not reliably convey the target seek time through the
currentTime.  If seekTo() is used,  the value is captured  and  conveyed through vgSeeking as the
$currentTime.  Otherwise uses the  target.currentTime.

BREAKING CHANGE: vgSeeking $currentTime value will be the seekTo() time, if the API was used. Although, this does match the intended (documented) behavior.

